### PR TITLE
Better time checking in key cleanup.

### DIFF
--- a/keyrotator/cleanup.py
+++ b/keyrotator/cleanup.py
@@ -54,7 +54,7 @@ class CleanupCommand(object):
 
       diff_time = current_datetime - key_creation_time
 
-      if diff_time.days > signed_key_max_age:
+      if diff_time.days >= signed_key_max_age:
         logging.info("Found invalid key %s created %s", key["name"],
                      key_creation_time)
         invalid_keys.append(key)


### PR DESCRIPTION
Support a more expected time check. This uses >= rather than >.

Behavior for a 1 day expiration becomes `--key-max-age=1` rather than `--key-max-age=0.`